### PR TITLE
Prevent admin bar from overlaying gallery controls

### DIFF
--- a/css-dev/burf-theme/_gallery.scss
+++ b/css-dev/burf-theme/_gallery.scss
@@ -33,7 +33,7 @@ $wp-supported-gallery-columns: 9;
 	}
 }
 
-.logged-in.admin-bar {
+.admin-bar {
 	.lg-outer {
 		margin-top: 32px;
 	}


### PR DESCRIPTION
In [Pull 158](https://github.com/bu-ist/responsive-framework/pull/158) on Responsive Framework, we are improving the WordPress core gallery experience. However, when the gallery is open, the controls are hidden by the admin bar when logged in.

This pull request fixes this in my sandbox.

![Fixed problem](https://cloudup.com/cbKpSzBdIEW+)
