### PR TITLE
added -webkit-clip-path to %visually-hidden, .u-visually-hidden as we…

### DIFF
--- a/css-dev/burf-base/_mixins.scss
+++ b/css-dev/burf-base/_mixins.scss
@@ -581,6 +581,7 @@
 .u-visually-hidden {
 	border: 0;
 	clip: rect( 0, 0, 0, 0 ); // Deprecated. Remove when clip-path support is better.
+	-webkit-clip-path: inset( 50% );
 	clip-path: inset( 50% );
 	height: 1px;
 	margin: -1px;
@@ -603,6 +604,7 @@
 
 %remove-visually-hidden {
 	clip: auto;
+	-webkit-clip-path: none;
 	clip-path: none;
 	height: auto;
 	margin: 0;


### PR DESCRIPTION
…ll as %remove-visually-hidden mixins. Otherwise already conforms to WP 4.9 use of clip and clip-path as described: https://make.wordpress.org/core/2017/10/22/changes-to-the-screen-reader-text-css-class-in-wordpress-4-9/.