### PR TITLE
removed $family-base from $normalize so it will not override -family-…

### DIFF
--- a/css-dev/burf-base/_normalize.scss
+++ b/css-dev/burf-base/_normalize.scss
@@ -2,15 +2,6 @@
 // Global Settings
 // =================================================================
 
-/// Controls the default font used across the site.
-/// Affects body text and anything else that isn't
-/// specifically overridden.
-/// @group global
-/// @access public
-/// @since 1.0.0
-
-$font-family-base:                          "TiemposText", Georgia, serif !default;
-
 /// Controls the default font size used across the site.
 /// Affects body text and anything else that isn't
 /// specifically overridden.


### PR DESCRIPTION
…base in _typography despite import order in burf-base.scss (both variables were set to !default).