### PR TITLE
Move the jQuery wrap to grunt concat

### DIFF
--- a/js-dev/toggle.js
+++ b/js-dev/toggle.js
@@ -1,31 +1,30 @@
 /**
  * Toggle behavior for navigation / search buttons.
  */
-( function ( $ ) {
-	var $body = $( 'body' ),
-		 $toggle = $( '.js-nav-toggle' ),
-		 $toggleitems = $toggle.add( 'nav' ),
-		 $searchtoggle = $( '.js-search-toggle' ),
-		 $searchitems = $searchtoggle.add( '#quicksearch' );
 
-	$toggle.on( 'click', function ( e ) {
-		e.preventDefault();
-		$toggleitems.toggleClass( 'is-open' );
-		$searchitems.removeClass( 'is-open' );
-		$body.toggleClass( 'nav-open' ).removeClass( 'search-open' );
-	});
+var $body = $( 'body' ),
+	 $toggle = $( '.js-nav-toggle' ),
+	 $toggleitems = $toggle.add( 'nav' ),
+	 $searchtoggle = $( '.js-search-toggle' ),
+	 $searchitems = $searchtoggle.add( '#quicksearch' );
 
-	$searchtoggle.on( 'click', function ( e ) {
-		e.preventDefault();
-		$toggleitems.removeClass( 'is-open' );
+$toggle.on( 'click', function ( e ) {
+	e.preventDefault();
+	$toggleitems.toggleClass( 'is-open' );
+	$searchitems.removeClass( 'is-open' );
+	$body.toggleClass( 'nav-open' ).removeClass( 'search-open' );
+});
 
-		if( ! $( this ).hasClass( 'is-open' ) ){
-			setTimeout(function(){
-				$( '#q' ).focus();
-			}, 100 );
-		}
+$searchtoggle.on( 'click', function ( e ) {
+	e.preventDefault();
+	$toggleitems.removeClass( 'is-open' );
 
-		$searchitems.toggleClass( 'is-open' );
-		$body.toggleClass( 'search-open' ).removeClass('nav-open');
-	});
-} ( jQuery ) );
+	if( ! $( this ).hasClass( 'is-open' ) ){
+		setTimeout(function(){
+			$( '#q' ).focus();
+		}, 100 );
+	}
+
+	$searchitems.toggleClass( 'is-open' );
+	$body.toggleClass( 'search-open' ).removeClass('nav-open');
+});


### PR DESCRIPTION
This pull request moves the jQuery function wrap to the grunt concat task in Framework, and removes it from Foundation accordingly.

The idea behind concatenating multiple files from js-dev to scripts.js is great, but in order for jQuery to work as we normally write it in WordPress, it needs a wrapper to know `$` is shorthand for `jQuery`. This used to be in each individual file, which meant if you broke up your files into multiple parts, you had a LOT of these wrappers. With a single wrapper using the `header` and `footer` options in grunt-concat, we can combine them, save a bit of time, and keep things easier to read. 

Needs to be merged in tandem with https://github.com/bu-ist/responsive-framework/pull/299