### PR TITLE
Blockquote Styling

### DIFF
--- a/css-dev/burf-base/_typography.scss
+++ b/css-dev/burf-base/_typography.scss
@@ -606,7 +606,7 @@ blockquote {
 	}
 	&.oscar {
 		border-left: 0.45em solid #0f69d7;
-		background: #f0f0f0; // $color-grayscale-f0: tint-gray
+		background: $color-grayscale-f0;
 		&>p {
 			padding: 0 18px;
 		}
@@ -625,7 +625,7 @@ blockquote {
 			// Position 
 			position: absolute;
 			left: 14px;
-			top: -0.55em; // -2px
+			top: 2px;
 
 			// Font & Color
 			content: "\201C"; // Unicode for Left Double Quote 


### PR DESCRIPTION
Modifies _typography, providing 4 basic styles: large dquote to the left of text block, large bold dquote above text block, text block enclosed in grey box with left blue border (no quote), text block enclosed in grey box with darker grey left border and larg(ish) dquote floating above.

Each style is applied by adding a class to the <blockquote> element. For now, the classes have silly names, based on characters from _Arrested Development_: .michael, .lucille, .oscar, and .gob.

I have set <blockquote> base style to $font-family-serif; this could be removed, but when converted to the theme's default sans serif font, vertical position of the quote in the .gob (grey box / grey border) style will change.

Examples here: http://tdodson.cms-devl.bu.edu/bluth-blockquotes/

Examples each are multi-paragraph, repeat same text in each <p>