### PR TITLE
Update `row` class to play nicely with large size grid containers

### DIFF
--- a/css-dev/burf-base/grid/_grid-placeholders.scss
+++ b/css-dev/burf-base/grid/_grid-placeholders.scss
@@ -52,7 +52,7 @@
 	margin: $grid-row-margin;
 
 	@include breakpoint( $sm ) {
-		margin-right: 0;
+		margin: $grid-row-margin-desktop;
 	}
 }
 
@@ -63,7 +63,8 @@
 /// @since 1.2.0
 
 %row-child-styles {
-	padding: $grid-column-padding;
+	padding-left: $grid-column-padding;
+	padding-right: $grid-column-padding;
 }
 
 /// A backwards-compatible equal heights solution for
@@ -140,6 +141,7 @@
 .col-margin-parent,
 %col-margin-parent {
 	margin-left: -$grid-margin-width#{"%"};
+	margin-right: 0;
 }
 
 /// A private map to hold grid widths while

--- a/css-dev/burf-base/grid/_package.scss
+++ b/css-dev/burf-base/grid/_package.scss
@@ -109,7 +109,7 @@ $grid-row-margin-desktop:                          0 -#{$grid-container-padding-
 /// @access public
 /// @since 1.0.0
 
-$grid-column-padding:                      0 $padding !default;
+$grid-column-padding:                      $padding !default;
 
 /// Controls the padding on child items of the grid using the
 /// -margin class. Does not affect other margin classes.
@@ -117,7 +117,7 @@ $grid-column-padding:                      0 $padding !default;
 /// @access public
 /// @since 2.0.0
 
-$grid-margin-padding:                      $padding-small !default;
+$grid-margin-padding:                      $padding !default;
 
 // =================================================================
 // Grid Styles and Placeholders


### PR DESCRIPTION
This pull request adds variables to keep the row class and content container classes connected. Currently, the row class doesn't increase the negative margin to match the content container so that it's actually pulling back the amount it should.

**Page where issue was discovered:**
http://nm.cms-devl.bu.edu/hub-infographic/12-2/

**Example pages:**
http://bun.cms-devl.bu.edu/hub-infographic/12-2/
http://bun.cms-devl.bu.edu/responsi/bootstrap-grid/