### PR TITLE
Allow social icons in any type of menu except primary nav

### DIFF
--- a/css-dev/burf-theme/layout/_footer.scss
+++ b/css-dev/burf-theme/layout/_footer.scss
@@ -262,6 +262,17 @@ body {
 		@include transition( color 200ms ease-in-out 0s );
 		font-size: $font-size-icon;
 	}
+}
+
+/// Styles social links in menus.
+/// @group widgets
+/// @access public
+/// @since 2.0.0
+
+.menu-item {
+	a::before {
+		margin-right: 0.5em;
+	}
 
 	[href*="dropbox.com"] {
 		@extend %icon-dropbox;


### PR DESCRIPTION
Currently, we only have CSS to apply social icons to the footer social menu. This means if you choose to move the social menu elsewhere, you lose all icons. While we can't predict if text should or shouldn't be hidden, or if icons should show inline, as in the footer, we can say with pretty reasonable certainty that the icons should be there. This changes the CSS to apply icons to menu items more broadly, and sets a default icon spacing just in case you add icons to something that isn't supported by default.

Screenshots (the "widget" version is new):

<img width="698" alt="screen shot 2018-04-03 at 1 46 18 pm" src="https://user-images.githubusercontent.com/1828613/38265989-7bcac560-3745-11e8-818b-1b8e5c14285d.png">

<img width="350" alt="screen shot 2018-04-03 at 1 46 25 pm" src="https://user-images.githubusercontent.com/1828613/38265998-7f9d569e-3745-11e8-9671-077e7e8ba712.png">


Live example here: http://bun.cms-devl.bu.edu/responsi/