### PR TITLE
Prevent single column gallery from upsizing images

### DIFF
--- a/css-dev/burf-theme/content/_galleries.scss
+++ b/css-dev/burf-theme/content/_galleries.scss
@@ -79,6 +79,20 @@ $color-gallery-overlay: rgba( $color-grayscale-0, 0.75 ) !default;
 	}
 }
 
+.gallery-columns-1 {
+	.gallery-item {
+		float: none;
+		margin-left: auto;
+		margin-right: auto;
+		max-height: 80vh;
+		width: auto;
+	}
+
+	img {
+		width: auto;
+	}
+}
+
 .gallery-icon {
 	a {
 		@extend %icon-scaleup;


### PR DESCRIPTION
Introduces styles to prevent image upscaling on single column galleries. 

See example here: http://bun.cms-devl.bu.edu/responsi/wp-gallery-test/