### PR TITLE
Incorporating BU Hub Indicator + Webfont for Responsi

### DIFF
--- a/css-dev/burf-base/_config.scss
+++ b/css-dev/burf-base/_config.scss
@@ -588,6 +588,14 @@ $color-grayscale-f5:                       tint-gray( #f5f5f5 );
 
 $color-grayscale-f:                        tint-gray( #fff );
 
+/// A grayscale variable for hover state of the BU Hub webfont.
+/// @group 01-config
+/// @type color
+/// @access public
+/// @since 2.0.0
+
+$color-hub: #767676;
+
 // -----------------------------------------------------------------
 // -----------------------------------------------------------------
 // -----------------------------------------------------------------

--- a/css-dev/burf-base/_config.scss
+++ b/css-dev/burf-base/_config.scss
@@ -588,13 +588,13 @@ $color-grayscale-f5:                       tint-gray( #f5f5f5 );
 
 $color-grayscale-f:                        tint-gray( #fff );
 
-/// A grayscale variable for hover state of the BU Hub webfont.
+/// A grayscale variable for hover state of the BU Hub webfont. Not intended for editing.
 /// @group 01-config
 /// @type color
 /// @access public
 /// @since 2.0.0
 
-$color-hub: #767676;
+$color-hub:                        			 #767676;
 
 // -----------------------------------------------------------------
 // -----------------------------------------------------------------

--- a/css-dev/burf-base/_fonts.scss
+++ b/css-dev/burf-base/_fonts.scss
@@ -83,3 +83,18 @@
 	font-style: italic;
 	font-weight: 700;
 }
+
+// BU Default Icons
+// -----------------------------------------------------------------
+
+@font-face {
+	font-family: "BU-Default-Icons";
+	src: url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.eot");
+	src: url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.eot?#iefix") format("embedded-opentype"),
+		url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.woff") format("woff"),
+		url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.ttf") format("truetype"),
+		url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.svg#bu-default-icons") format("svg");
+	font-style: normal;
+	font-weight: 400;
+	// unicode-range:U+??????; /* Include all Unicode possiblities */
+}

--- a/css-dev/burf-base/_fonts.scss
+++ b/css-dev/burf-base/_fonts.scss
@@ -93,7 +93,7 @@
 	src: url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.eot?#iefix' ) format( 'embedded-opentype' ),
 		url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.woff' ) format( 'woff' ),
 		url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.ttf' ) format( 'truetype' ),
-		url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.svg#bu-default-icons' ) format( 'svg');
+		url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.svg#bu-default-icons' ) format( 'svg' );
 	font-style: normal;
 	font-weight: 400;
 	// unicode-range:U+??????; /* Include all Unicode possiblities */

--- a/css-dev/burf-base/_fonts.scss
+++ b/css-dev/burf-base/_fonts.scss
@@ -88,12 +88,12 @@
 // -----------------------------------------------------------------
 
 @font-face {
-	font-family: "BU-Default-Icons";
-	src: url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.eot");
-	src: url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.eot?#iefix") format("embedded-opentype"),
-		url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.woff") format("woff"),
-		url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.ttf") format("truetype"),
-		url("https://www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.svg#bu-default-icons") format("svg");
+	font-family: 'BU-Default-Icons';
+	src: url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.eot' );
+	src: url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.eot?#iefix' ) format( 'embedded-opentype' ),
+		url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.woff' ) format( 'woff' ),
+		url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.ttf' ) format( 'truetype' ),
+		url( '//www.bu.edu/cdn/fonts/icons/bu-default-icons/bu-default-icons.svg#bu-default-icons' ) format( 'svg');
 	font-style: normal;
 	font-weight: 400;
 	// unicode-range:U+??????; /* Include all Unicode possiblities */

--- a/css-dev/burf-base/icons/_supported.scss
+++ b/css-dev/burf-base/icons/_supported.scss
@@ -261,6 +261,11 @@ $icons-responsive: (
 	checkbox-filled: "\ED53",
 	radio-empty: "\ED54",
 	radio-filled: "\ED55",
+
+	// BU Hub Indicator
+
+	buhub: '\F700',
+	questionmark: '\2753',
 );
 
 // Merges custom icons and overrides with the default supported icons map.

--- a/css-dev/burf-base/icons/_ui.scss
+++ b/css-dev/burf-base/icons/_ui.scss
@@ -49,7 +49,7 @@
 /// The radio - empty icon.
 /// @example scss - Add the radio - empty icon to a menu item
 /// .menu-item {
-///    @extend %icon-radio-empty;
+///    @extend %icon-checkbox-filled;
 /// }
 /// @group icons
 /// @access public
@@ -62,7 +62,7 @@
 /// The radio - filled icon.
 /// @example scss - Add the radio - filled icon to a menu item
 /// .menu-item {
-///    @extend %icon-radio-filled;
+///    @extend %icon-radio-empty;
 /// }
 /// @group icons
 /// @access public
@@ -70,4 +70,30 @@
 
 %icon-radio-filled {
 	@include icon( "radio-filled" );
+}
+
+/// BU Hub Wordmark Logo
+/// @example scss - Add the radio - filled icon to a menu item
+/// .menu-item {
+///    @extend %icon-buhub;
+/// }
+/// @group icons
+/// @access public
+/// @since 2.0.0
+
+%icon-buhub {
+	@include icon( "buhub" );
+}
+
+/// BU Hub Question Mark Icon
+/// @example scss - Add the radio - filled icon to a menu item
+/// .menu-item {
+///    @extend %icon-questionmark;
+/// }
+/// @group icons
+/// @access public
+/// @since 2.0.0
+
+%icon-questionmark {
+	@include icon( "questionmark" );
 }

--- a/css-dev/burf-base/icons/_ui.scss
+++ b/css-dev/burf-base/icons/_ui.scss
@@ -82,7 +82,7 @@
 /// @since 2.0.0
 
 %icon-buhub {
-	@include icon( "buhub" );
+	@include icon( 'buhub' );
 }
 
 /// BU Hub Question Mark Icon
@@ -95,5 +95,5 @@
 /// @since 2.0.0
 
 %icon-questionmark {
-	@include icon( "questionmark" );
+	@include icon( 'questionmark' );
 }

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -118,8 +118,12 @@ $border-coursefeed:							 $border !default;
 	}
 }
 
+// =================================================================
+// BU Hub Indicator Styles
+// =================================================================
+
+
 /// BU Hub Indicator Wrapper
-/// Styles for BU Hub Areas Indicator
 /// @group 09-content
 /// @access public
 /// @since 2.0.0
@@ -130,11 +134,28 @@ $border-coursefeed:							 $border !default;
 	margin: 0 0 20px 20px;
 	max-width: 305px;
 	width: 100%;
+
+	.cf-course-card & {
+		// This breakpoint is explicit and shouldn’t be altered.
+		@include breakpoint( 525px ) {
+			float: right;
+		}
+	}
 }
+
+/// BU Hub Indicator Title
+/// @group 09-content
+/// @access public
+/// @since 2.0.0
 
 .cf-hub-head {
 	text-decoration: none;
 }
+
+/// BU Hub Indicator Title Iconstyles
+/// @group 09-content
+/// @access public
+/// @since 2.0.0
 
 .bu-hub-iconstyles {
 	display: inline-block;
@@ -144,39 +165,48 @@ $border-coursefeed:							 $border !default;
 
 	&::before {
 		color: $color-grayscale-5;
-		content: attr( data-icon );
-		font-family: 'BU-Default-Icons';
+		display: block;
 		font-size: 65px;
 		height: 25px;
 		line-height: 16px;
 		overflow: hidden;
-		speak: none;
 		width: 90px;
+
+		a:hover & {
+			color: $color-hub;
+		}
 	}
+
 }
 
-.icon-buhub::before {
-	content: '\F700';
+/// BU Hub Indicator Title Logo Webfont Icon
+/// @group 09-content
+/// @access public
+/// @since 2.0.0
+
+.bu-hub-iconstyles.icon-buhub::before {
+	margin-right: 0;
 	width: 70px;
 }
 
-.icon-questionmark::before {
-	content: '\2753';
+/// BU Hub Indicator Title Question Mark Webfont Icon
+/// @group 09-content
+/// @access public
+/// @since 2.0.0
+
+.bu-hub-iconstyles.icon-questionmark::before {
 	font-size: 16px;
 	line-height: 17px;
 }
 
-.icon-buhub::before,
-.icon-questionmark::before {
-	display: block;
-
-	a:hover & {
-		color: $color-hub;
-	}
-}
+/// BU Hub Indicator Area <ul> List
+/// @group 09-content
+/// @access public
+/// @since 2.0.0
 
 .cf-hub-offerings {
 	color: $color-hub;
+	// ! Regardless where this lives, always maintain consistent use of Benton.
 	font-family: "Benton-Sans", Arial, "Helvetica Neue", Helvetica, sans-serif;
 	font-size: 12px;
 	font-weight: 300;
@@ -186,11 +216,5 @@ $border-coursefeed:							 $border !default;
 
 	li {
 		margin-bottom: 7px;
-	}
-}
-
-@media ( min-width: 525px ) {
-	.cf-course-card .cf-hub-ind {
-		float: right;
 	}
 }

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -177,26 +177,15 @@ $border-coursefeed:							 $border !default;
 		}
 	}
 
-}
+	&.icon-buhub::before {
+		margin-right: 0;
+		width: 70px;
+	}
 
-/// BU Hub Indicator Title Logo Webfont Icon
-/// @group 09-content
-/// @access public
-/// @since 2.0.0
-
-.bu-hub-iconstyles.icon-buhub::before {
-	margin-right: 0;
-	width: 70px;
-}
-
-/// BU Hub Indicator Title Question Mark Webfont Icon
-/// @group 09-content
-/// @access public
-/// @since 2.0.0
-
-.bu-hub-iconstyles.icon-questionmark::before {
-	font-size: 16px;
-	line-height: 17px;
+	&.icon-questionmark::before {
+		font-size: 16px;
+		line-height: 17px;
+	}
 }
 
 /// BU Hub Indicator Area <ul> List

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -7,7 +7,7 @@
 /// @access public
 /// @since 2.0.0
 
-$border-coursefeed:               $border !default;
+$border-coursefeed:							 $border !default;
 
 // =================================================================
 // Course Feed Styles
@@ -22,7 +22,7 @@ $border-coursefeed:               $border !default;
 	border-top: $border-coursefeed;
 	margin-top: $margin;
 	padding-top: $padding;
-  clear: right;
+	clear: right;
 
 	&:first-child {
 		border: 0;
@@ -125,69 +125,72 @@ $border-coursefeed:               $border !default;
 /// @since 2.0.0
 
 .cf-hub-ind {
-  display: block;
-  max-width: 305px;
-  width: 100%;
-  margin: 0px 0px 20px 20px;
-  float: unset;
+	display: block;
+	float: unset;
+	margin: 0 0 20px 20px;
+	max-width: 305px;
+	width: 100%;
 }
 
 .cf-hub-head {
-  text-decoration: none;
+	text-decoration: none;
 }
 
 .bu-hub-iconstyles {
-  display: inline-block;
-  height: 25px;
-  overflow: hidden;
-  margin: 5px 0px;
-  &:before {
-    height: 25px;
-    width: 90px;
-    font-family: "BU-Default-Icons";
-    font-size: 65px;
-    overflow: hidden;
-    content: attr(data-icon);
-    speak: none;
-    color: #555555;
-    line-height: 16px;
-  }
+	display: inline-block;
+	height: 25px;
+	margin: 5px 0;
+	overflow: hidden;
+
+	&::before {
+		color: $color-grayscale-5;
+		content: attr( data-icon );
+		font-family: 'BU-Default-Icons';
+		font-size: 65px;
+		height: 25px;
+		line-height: 16px;
+		overflow: hidden;
+		speak: none;
+		width: 90px;
+	}
 }
 
-.icon-buhub:before {
-  content: "\F700";
-  width: 70px;
+.icon-buhub::before {
+	content: '\F700';
+	width: 70px;
 }
 
-.icon-questionmark:before {
-  content: "\2753";
-  font-size: 16px;
-  line-height: 17px;
+.icon-questionmark::before {
+	content: '\2753';
+	font-size: 16px;
+	line-height: 17px;
 }
 
-.icon-buhub:before, .icon-questionmark:before {
-  display: block;
-  a:hover & {
-    color: #767676;
-  }
+.icon-buhub::before,
+.icon-questionmark::before {
+	display: block;
+
+	a:hover & {
+		color: #767676;
+	}
 }
 
 .cf-hub-offerings {
-  list-style-type: none;
-  margin: 5px 0px 10px 0px;
-  font-size: 12px;
-  font-weight: 300;
-  font-family: "Benton-Sans", Arial, "Helvetica Neue", Helvetica, sans-serif;
-  color: #767676;
-  padding: 0px;
-  margin: -5px 0px 10px;
-  li {
-    margin-bottom: 7px;
-  }
+	color: #767676;
+	font-family: "Benton-Sans", Arial, "Helvetica Neue", Helvetica, sans-serif;
+	font-size: 12px;
+	font-weight: 300;
+	list-style-type: none;
+	margin: -5px 0 10px;
+	padding: 0;
+
+	li {
+		margin-bottom: 7px;
+	}
 }
 
-@media (min-width: 525px) {
-  .cf-course-card .cf-hub-ind {
-    float: right;
-  }
+@media ( min-width: 525px ) {
+	.cf-course-card .cf-hub-ind {
+		float: right;
+	}
 }

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -20,9 +20,9 @@ $border-coursefeed:							 $border !default;
 
 .cf-course {
 	border-top: $border-coursefeed;
+	clear: right;
 	margin-top: $margin;
 	padding-top: $padding;
-	clear: right;
 
 	&:first-child {
 		border: 0;

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -171,12 +171,12 @@ $border-coursefeed:							 $border !default;
 	display: block;
 
 	a:hover & {
-		color: #767676;
+		color: $color-hub;
 	}
 }
 
 .cf-hub-offerings {
-	color: #767676;
+	color: $color-hub;
 	font-family: "Benton-Sans", Arial, "Helvetica Neue", Helvetica, sans-serif;
 	font-size: 12px;
 	font-weight: 300;

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -22,6 +22,7 @@ $border-coursefeed:               $border !default;
 	border-top: $border-coursefeed;
 	margin-top: $margin;
 	padding-top: $padding;
+  clear: right;
 
 	&:first-child {
 		border: 0;
@@ -117,16 +118,6 @@ $border-coursefeed:               $border !default;
 	}
 }
 
-
-@font-face {
-  font-family: 'bu-hub-iconstyles';
-  src: url('icons/bu-hub-webfont.eot');
-  src: url('icons/bu-hub-webfont.eot?#iefix') format("embedded-opentype"), url('icons/bu-hub-webfont.woff2') format("woff2"), url('icons/bu-hub-webfont.woff') format("woff");
-  font-weight: normal;
-  font-style: normal;
-}
-
-
 /// BU Hub Indicator Wrapper
 /// Styles for BU Hub Areas Indicator
 /// @group 09-content
@@ -134,79 +125,64 @@ $border-coursefeed:               $border !default;
 /// @since 2.0.0
 
 .cf-hub-ind {
-  margin-top: 5px;
+  display: block;
   max-width: 305px;
-  border-bottom: 1px solid #ccc;
+  width: 100%;
+  margin: 0px 0px 20px 20px;
+  float: unset;
 }
 
 .cf-hub-head {
   text-decoration: none;
-  margin-bottom: 5px;
 }
 
 .bu-hub-iconstyles {
   display: inline-block;
   height: 25px;
-  width: 64px;
   overflow: hidden;
   margin: 5px 0px;
   &:before {
-    display: inline-block;
     height: 25px;
     width: 90px;
-    font-family: "bu-hub-iconstyles";
+    font-family: "BU-Default-Icons";
     font-size: 65px;
     overflow: hidden;
     content: attr(data-icon);
     speak: none;
     color: #555555;
-    line-height: 0px;
+    line-height: 16px;
   }
 }
 
 .icon-buhub:before {
-  content: "\e001";
+  content: "\F700";
+  width: 70px;
 }
 
 .icon-questionmark:before {
-  line-height: 10px;
-  margin-left: -2px;
-  font-size: 32px;
-  content: "\e002";
+  content: "\2753";
+  font-size: 16px;
+  line-height: 17px;
 }
 
 .icon-buhub:before, .icon-questionmark:before {
+  display: block;
   a:hover & {
     color: #767676;
   }
 }
 
 .cf-hub-offerings {
-  display: block;
   list-style-type: none;
   margin: 5px 0px 10px 0px;
   font-size: 12px;
   font-weight: 300;
   font-family: "Benton-Sans", Arial, "Helvetica Neue", Helvetica, sans-serif;
   color: #767676;
+  padding: 0px;
+  margin: -5px 0px 10px;
   li {
-    margin-bottom: 10px;
-  }
-}
-
-/* Responsi Theme Hub Indicator Overrides */
-
-.cf-course {
-  clear: right;
-}
-
-.cf-course-card .cf-hub-ind {
-  float: unset;
-  display: block;
-  border-bottom: initial;
-  .cf-hub-offerings {
-    padding: 0px;
-    margin: -5px 0px 10px;
+    margin-bottom: 7px;
   }
 }
 

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -116,3 +116,102 @@ $border-coursefeed:               $border !default;
 		content: "Prerequisites: ";
 	}
 }
+
+
+@font-face {
+  font-family: 'bu-hub-iconstyles';
+  src: url('icons/bu-hub-webfont.eot');
+  src: url('icons/bu-hub-webfont.eot?#iefix') format("embedded-opentype"), url('icons/bu-hub-webfont.woff2') format("woff2"), url('icons/bu-hub-webfont.woff') format("woff");
+  font-weight: normal;
+  font-style: normal;
+}
+
+
+/// BU Hub Indicator Wrapper
+/// Styles for BU Hub Areas Indicator
+/// @group 09-content
+/// @access public
+/// @since 2.0.0
+
+.cf-hub-ind {
+  margin-top: 5px;
+  max-width: 305px;
+  border-bottom: 1px solid #ccc;
+}
+
+.cf-hub-head {
+  text-decoration: none;
+  margin-bottom: 5px;
+}
+
+.bu-hub-iconstyles {
+  display: inline-block;
+  height: 25px;
+  width: 64px;
+  overflow: hidden;
+  margin: 5px 0px;
+  &:before {
+    display: inline-block;
+    height: 25px;
+    width: 90px;
+    font-family: "bu-hub-iconstyles";
+    font-size: 65px;
+    overflow: hidden;
+    content: attr(data-icon);
+    speak: none;
+    color: #555555;
+    line-height: 0px;
+  }
+}
+
+.icon-buhub:before {
+  content: "\e001";
+}
+
+.icon-questionmark:before {
+  line-height: 10px;
+  margin-left: -2px;
+  font-size: 32px;
+  content: "\e002";
+}
+
+.icon-buhub:before, .icon-questionmark:before {
+  a:hover & {
+    color: #767676;
+  }
+}
+
+.cf-hub-offerings {
+  display: block;
+  list-style-type: none;
+  margin: 5px 0px 10px 0px;
+  font-size: 12px;
+  font-weight: 300;
+  font-family: "Benton-Sans", Arial, "Helvetica Neue", Helvetica, sans-serif;
+  color: #767676;
+  li {
+    margin-bottom: 10px;
+  }
+}
+
+/* Responsi Theme Hub Indicator Overrides */
+
+.cf-course {
+  clear: right;
+}
+
+.cf-course-card .cf-hub-ind {
+  float: unset;
+  display: block;
+  border-bottom: initial;
+  .cf-hub-offerings {
+    padding: 0px;
+    margin: -5px 0px 10px;
+  }
+}
+
+@media (min-width: 525px) {
+  .cf-course-card .cf-hub-ind {
+    float: right;
+  }
+}


### PR DESCRIPTION
Styles applied to new BU Hub Indicator for Course Feeds in Responsi.
The Indicator can be viewed here: http://nm.cms-devl.bu.edu/responsi/news/course-feeds/

What’s left is incorporating CDN font URL’s when the time comes.