### PR TITLE
Hotfix/sidenav search banner push

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+* Fixed a bug with the left hand nav layout and BU Banners [See related pull request](https://github.com/bu-ist/responsive-foundation/pull/154)
+
 ## 2.0.1
 
 * Adds support for BU Hub Indicator within Course Feeds.

--- a/css-dev/burf-theme/layout/_navigation.scss
+++ b/css-dev/burf-theme/layout/_navigation.scss
@@ -808,7 +808,7 @@ $left-nav-desktop:                    $nav-desktop !default;
 	}
 }
 
-$_search-height: 103px;
+$_search-height: 115px;
 
 .search-open.l-side-nav {
 	.primary-nav,

--- a/css-dev/burf-theme/layout/_navigation.scss
+++ b/css-dev/burf-theme/layout/_navigation.scss
@@ -811,7 +811,8 @@ $left-nav-desktop:                    $nav-desktop !default;
 $_search-height: 103px;
 
 .search-open.l-side-nav {
-	.primary-nav {
+	.primary-nav,
+	.bu-banner {
 		@include breakpoint( $left-nav-desktop ) {
 			top: $_search-height; // adds the height of the open search form
 		}

--- a/css-dev/burf-theme/layout/_navigation.scss
+++ b/css-dev/burf-theme/layout/_navigation.scss
@@ -868,7 +868,9 @@ $_search-height: 103px;
 	}
 
 	&.nav-open {
-		.content {
+		.bu-banner,
+		.content
+		 {
 			@include breakpoint( $left-nav-desktop ) {
 				left: $width-side-nav - 60px;
 			}


### PR DESCRIPTION
- Added .bu-banner to .nav-open and .search-open styles
- Increased the search-height variable

Example URL:
http://responsi.cms-devl.bu.edu/responsi-sidenav/