### PR TITLE
Hotfix/search button ie fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Fixed a bug with the left hand nav layout and BU Banners [See related pull request](https://github.com/bu-ist/responsive-foundation/pull/154)
+* Fixed a bug with the search box in IE
 
 ## 2.0.1
 

--- a/bower.json
+++ b/bower.json
@@ -12,7 +12,8 @@
     "Inder Singh <isingh@bu.edu>",
     "Ashley Kolodziej <kolodz10@bu.edu>",
     "Jon Desroisers <jondes@bu.edu>",
-    "Tom Dodson <tdodson@bu.edu>"
+    "Tom Dodson <tdodson@bu.edu>",
+    "Andrea Cacase <acacase@bu.edu>"
   ],
   "description": "A front-end framework for developing responsive sites at Boston University.",
   "main": [

--- a/css-dev/burf-theme/layout/_navigation.scss
+++ b/css-dev/burf-theme/layout/_navigation.scss
@@ -357,7 +357,7 @@ $search-field-height:                          40px !default;
 	width: 75%;
 
 	@include breakpoint( $nav-desktop ) {
-		width: 85%;
+		width: 80%;
 	}
 }
 
@@ -370,7 +370,7 @@ $search-field-height:                          40px !default;
 	width: 25%;
 
 	@include breakpoint( $nav-desktop ) {
-		width: 15%;
+		width: 20%;
 	}
 }
 

--- a/css-dev/burf-theme/layout/_navigation.scss
+++ b/css-dev/burf-theme/layout/_navigation.scss
@@ -336,7 +336,7 @@ nav {
 	}
 
 	label {
-		display: initial;
+		display: inline;
 	}
 }
 


### PR DESCRIPTION
Related to Issue https://github.com/bu-ist/responsive-foundation/issues/155

- Changed display of label to inline
- Adjusted percentages of field/button sizes for desktop view 

Example URL:
http://responsi.cms-devl.bu.edu/responsi-sidenav/404