### PR TITLE
Added height to profile photo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@
 ## Unreleased
 
 * Fixed a bug with the left hand nav layout and BU Banners [See related pull request](https://github.com/bu-ist/responsive-foundation/pull/154)
-* Fixed a bug with the search box in IE
+* Fixed a bug with the search box in IE [See related pull request](https://github.com/bu-ist/responsive-foundation/pull/156)
+* Fixed a bug with the profile single photos [See related pull request](https://github.com/bu-ist/responsive-foundation/pull/159)
 
 ## 2.0.1
 

--- a/css-dev/burf-theme/profiles/_profile-single.scss
+++ b/css-dev/burf-theme/profiles/_profile-single.scss
@@ -40,6 +40,7 @@ $color-profile-info-item:					$color-grayscale-5 !default;
 /// @since 2.0.0
 
 .profile-single-photo {
+	height: 300px;
 	margin: 0 auto $margin;
 	width: 300px;
 }


### PR DESCRIPTION
- Added a 300px height to .profile-single-photo

This fix is related to issue https://github.com/bu-ist/responsive-foundation/issues/158

Reference URLs:
http://responsi.cms-devl.bu.edu/responsi-sidenav/profile/mike-burns/
http://responsi.cms-devl.bu.edu/responsi-sidenav/profiles/profile-shortcodes/
