### PR TITLE
Hub Indicator Safeguards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,6 +58,7 @@ standards [See related pull request](https://github.com/bu-ist/responsive-founda
 * Better compliance with licensing rules for Normalize and Pure CSS
 [See related pull request](https://github.com/bu-ist/responsive-foundation/pull/59)
 * Assortment of bug fixes
+* Added BU Hub Indicator. Incorporated adjustments to line height and added a safeguard to prevent any custom theme styling of a bottom border under either the BU Hub wordmark or the question mark icon.
 
 # 1.4.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -58,7 +58,7 @@ standards [See related pull request](https://github.com/bu-ist/responsive-founda
 * Better compliance with licensing rules for Normalize and Pure CSS
 [See related pull request](https://github.com/bu-ist/responsive-foundation/pull/59)
 * Assortment of bug fixes
-* Added BU Hub Indicator. Incorporated adjustments to line height and added a safeguard to prevent any custom theme styling of a bottom border under either the BU Hub wordmark or the question mark icon.
+* Added BU Hub Indicator. Incorporated adjustments to line height.
 
 # 1.4.2
 

--- a/css-dev/burf-base/_config.scss
+++ b/css-dev/burf-base/_config.scss
@@ -614,4 +614,12 @@ $color-hub:                        			 #767676;
 /// @access public
 /// @since 1.2.0
 
-$border:										 1px solid $color-grayscale-d !default;
+$border:												1px solid $color-grayscale-d !default;
+
+/// No border.
+/// @group 01-config
+/// @access public
+/// @since 2.0.0
+
+$border-base:										0px solid $color-grayscale-f !default;
+

--- a/css-dev/burf-base/_config.scss
+++ b/css-dev/burf-base/_config.scss
@@ -621,5 +621,5 @@ $border:												1px solid $color-grayscale-d !default;
 /// @access public
 /// @since 2.0.0
 
-$border-base:										0px solid $color-grayscale-f !default;
+$border-base:										0 solid $color-grayscale-f !default;
 

--- a/css-dev/burf-base/_config.scss
+++ b/css-dev/burf-base/_config.scss
@@ -615,11 +615,3 @@ $color-hub:                        			 #767676;
 /// @since 1.2.0
 
 $border:												1px solid $color-grayscale-d !default;
-
-/// No border.
-/// @group 01-config
-/// @access public
-/// @since 2.0.0
-
-$border-base:										0 solid $color-grayscale-f !default;
-

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -180,6 +180,7 @@ $border-coursefeed:							 $border !default;
 	&.icon-buhub::before {
 		margin-right: 0;
 		width: 70px;
+		line-height: 8px;
 	}
 
 	&.icon-questionmark::before {
@@ -206,4 +207,13 @@ $border-coursefeed:							 $border !default;
 	li {
 		margin-bottom: 7px;
 	}
+}
+
+/// BU Hub Indicator: Whatever custom theme style overrides, NO bottom borders.
+/// @group 09-content
+/// @access public
+/// @since 2.0.0
+
+article[role="main"] .course-feed .cf-course .cf-hub-ind a {
+	border-bottom: $border-base;
 }

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -178,9 +178,9 @@ $border-coursefeed:							 $border !default;
 	}
 
 	&.icon-buhub::before {
+		line-height: 8px;
 		margin-right: 0;
 		width: 70px;
-		line-height: 8px;
 	}
 
 	&.icon-questionmark::before {
@@ -214,6 +214,6 @@ $border-coursefeed:							 $border !default;
 /// @access public
 /// @since 2.0.0
 
-article[role="main"] .course-feed .cf-course .cf-hub-ind a {
+article .course-feed .cf-course .cf-hub-ind a {
 	border-bottom: $border-base;
 }

--- a/css-dev/burf-theme/content/_courses.scss
+++ b/css-dev/burf-theme/content/_courses.scss
@@ -208,12 +208,3 @@ $border-coursefeed:							 $border !default;
 		margin-bottom: 7px;
 	}
 }
-
-/// BU Hub Indicator: Whatever custom theme style overrides, NO bottom borders.
-/// @group 09-content
-/// @access public
-/// @since 2.0.0
-
-article .course-feed .cf-course .cf-hub-ind a {
-	border-bottom: $border-base;
-}


### PR DESCRIPTION
--No Fix ID Number--

### Changes proposed in this pull request

* Updating the `line-height` on the BU Hub wordmark, to align with the question mark.

* Added a safeguard in **courses.scss** to prevent any custom theme code from accidentally adding any `border-bottom` code.

* Incorporated a `border` variable for no borders within the **config.scss** file.

### Review checklist

:ballot_box_with_check: I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
:ballot_box_with_check: I've updated `CHANGELOG.MD` with a brief explanation of the main changes in this pull request.
:ballot_box_with_check: My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
