### PR TITLE
Hotfix/disable external link styles

### DIFF
--- a/css-dev/burf-base/_normalize.scss
+++ b/css-dev/burf-base/_normalize.scss
@@ -108,8 +108,9 @@ figure {
 /// @group 01-config
 /// @access public
 /// @since 2.1.0
+/// TODO: This needs further testing with Hub course indicator.
 
-a {
+/*a {
 	&[target="_blank"],
 	&[target="_new"] {
 		@include icon( 'redirect', 'after' );
@@ -119,4 +120,4 @@ a {
 			vertical-align: text-top;
 		}
 	}
-}
+}*/


### PR DESCRIPTION
Disabling the external link styles for now due to unintended consequences for the Hub indicator.