### PR TITLE
Remove excess top margin on headings after visually hidden page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 3.0.2 (Planned)
 
 * Fixes skip link issues [#173](https://github.com/bu-ist/responsive-foundation/issues/173)
+* Fixes a spacing issue with hidden page titles [#174](https://github.com/bu-ist/responsive-foundation/issues/174)
 
 ## 3.0.1
 

--- a/css-dev/burf-base/_typography.scss
+++ b/css-dev/burf-base/_typography.scss
@@ -512,6 +512,10 @@ $_h: $_depth-headings;
 		font-size: 0.75em;
 		font-weight: normal;
 	}
+
+	.page-title.u-visually-hidden + & {
+		margin-top: 0;
+	}
 }
 
 /// Styles for all h1 tags.


### PR DESCRIPTION
Fixes #174 