### PR TITLE
Remove duplicate $font-family-base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 * Fixes skip link issues [#173](https://github.com/bu-ist/responsive-foundation/issues/173)
 * Fixes a spacing issue with hidden page titles [#174](https://github.com/bu-ist/responsive-foundation/issues/174)
+* Adds variable to control gallery margin [#174](https://github.com/bu-ist/responsive-foundation/issues/174)
+* Fixes [#103](https://github.com/bu-ist/responsive-foundation/issues/103)
 
 ## 3.0.1
 

--- a/css-dev/burf-base/_normalize.scss
+++ b/css-dev/burf-base/_normalize.scss
@@ -2,33 +2,6 @@
 // Global Settings
 // =================================================================
 
-/// Controls the default font used across the site.
-/// Affects body text and anything else that isn't
-/// specifically overridden.
-/// @group 01-config
-/// @access public
-/// @since 1.0.0
-
-$font-family-base:                          "TiemposText", Georgia, serif !default;
-
-/// Controls the default font size used across the site.
-/// Affects body text and anything else that isn't
-/// specifically overridden.
-/// @group 01-config
-/// @access public
-/// @since 1.0.0
-
-$font-size-base:                            18px !default;
-
-/// Controls the default line height used across the site.
-/// Affects body text and anything else that isn't
-/// specifically overridden.
-/// @group 01-config
-/// @access public
-/// @since 1.0.0
-
-$line-height-base:                          1.6 !default;
-
 /// Controls the default color used for text across the site.
 /// Affects body text and anything else that isn't
 /// specifically overridden.
@@ -72,18 +45,6 @@ html {
 	-moz-osx-font-smoothing: grayscale; // Normalizes font rendering in Firefox
 }
 
-/// Base styles and typography for all HTML elements.
-/// @group 01-config
-/// @access public
-/// @since 1.0.0
-
-body {
-	color: $color-base;
-	font-family: $font-family-base;
-	font-size: $font-size-base;
-	line-height: $line-height-base;
-}
-
 /// Controls spacing between section tags.
 /// @group 01-config
 /// @access public
@@ -101,23 +62,3 @@ figure {
 	height: auto;
 	max-width: 100%;
 }
-
-/// Adds a default icon for links which open
-/// in a new window or tab. This pattern may
-/// also be used for external links.
-/// @group 01-config
-/// @access public
-/// @since 2.1.0
-/// TODO: This needs further testing with Hub course indicator.
-
-/*a {
-	&[target="_blank"],
-	&[target="_new"] {
-		@include icon( 'redirect', 'after' );
-
-		&:after {
-			font-size: 0.6em;
-			vertical-align: text-top;
-		}
-	}
-}*/

--- a/css-dev/burf-base/_typography.scss
+++ b/css-dev/burf-base/_typography.scss
@@ -2,6 +2,31 @@
 // Typography Settings
 // =================================================================
 
+/// Controls the default font size used across the site.
+/// Affects body text and anything else that isn't
+/// specifically overridden.
+/// @group 01-config
+/// @access public
+/// @since 1.0.0
+
+$font-size-base:                            18px !default;
+
+/// Controls the default line height used across the site.
+/// Affects body text and anything else that isn't
+/// specifically overridden.
+/// @group 01-config
+/// @access public
+/// @since 1.0.0
+
+$line-height-base:                          1.6 !default;
+
+/// A serif font to use. This variable is not used by default.
+/// @group 01-config
+/// @access public
+/// @since 1.0.0
+
+$font-family-serif:                         "TiemposText", Georgia, serif !default;
+
 /// A sans-serif font to use sitewide.
 /// By default, this affects the site footer and label text in profiles.
 /// @group 04-typography
@@ -17,6 +42,13 @@ $font-family-sans-serif:                    "Benton-Sans", "Helvetica", sans-ser
 /// @since 1.0.0
 
 $font-family-monospace:                     "Consolas", "Liberation Mono", Courier, monospace !default;
+
+/// The default font for body copy.
+/// @group 01-config
+/// @access public
+/// @since 1.0.0
+
+$font-family-base:                          $font-family-sans-serif !default;
 
 /// A font to use for headings.
 /// Affects `<h1>`, `<h2>`, etc.
@@ -143,26 +175,22 @@ $font-padding-list:                         0 0 0 40px !default;
 
 $font-margin-dd:                            0 0 0 $margin !default;
 
-// Color and Typography
-// -----------------------------------------------------------------
-
-/// The default font for body copy.
-/// @group 01-config
-/// @access public
-/// @since 1.0.0
-
-$font-family-base:                          $font-family-sans-serif !default;
-
-/// A serif font to use. This variable is not used by default.
-/// @group 01-config
-/// @access public
-/// @since 1.0.0
-
-$font-family-serif:                         "TiemposText", Georgia, serif !default;
 
 // =================================================================
 // Typography Styles
 // =================================================================
+
+/// Base styles and typography for all HTML elements.
+/// @group 01-config
+/// @access public
+/// @since 1.0.0
+
+body {
+	color: $color-base;
+	font-family: $font-family-base;
+	font-size: $font-size-base;
+	line-height: $line-height-base;
+}
 
 // Links
 // -----------------------------------------------------------------


### PR DESCRIPTION
Removes a duplicate $font-family-base variable and moves a few styles that really belong in the typography partial out of normalize. Fixes #103 