### PR TITLE
Update tools-cgb with new icons implementation

### DIFF
--- a/css-dev/burf-tools/_tools-cgb.scss
+++ b/css-dev/burf-tools/_tools-cgb.scss
@@ -43,23 +43,7 @@ $burf-extras:								       false !default;
 $use-default-icons:                        false !default;
 $print-icon-classes:                       false !default;
 
-@import '~responsive-foundation/css-dev/burf-base/icons/base'; // Required
-@import '~responsive-foundation/css-dev/burf-base/icons/social'; // Required
-@import '~responsive-foundation/css-dev/burf-base/icons/actions'; // Required
-@import '~responsive-foundation/css-dev/burf-base/icons/arrows';
-@import '~responsive-foundation/css-dev/burf-base/icons/charts';
-@import '~responsive-foundation/css-dev/burf-base/icons/communication';
-@import '~responsive-foundation/css-dev/burf-base/icons/documents';
-@import '~responsive-foundation/css-dev/burf-base/icons/ecommerce';
-@import '~responsive-foundation/css-dev/burf-base/icons/editing';
-@import '~responsive-foundation/css-dev/burf-base/icons/location';
-@import '~responsive-foundation/css-dev/burf-base/icons/media';
-@import '~responsive-foundation/css-dev/burf-base/icons/objects';
-@import '~responsive-foundation/css-dev/burf-base/icons/status';
-@import '~responsive-foundation/css-dev/burf-base/icons/technology';
-@import '~responsive-foundation/css-dev/burf-base/icons/time';
-@import '~responsive-foundation/css-dev/burf-base/icons/transportation';
-@import '~responsive-foundation/css-dev/burf-base/icons/ui';
+@import '~responsive-foundation/css-dev/burf-base/icons/package';
 
 @import '~responsive-foundation/css-dev/burf-base/typography-variables';
 @import '~responsive-foundation/css-dev/burf-base/typography-tools';


### PR DESCRIPTION
We only need to import `icons/package` now. The package file will loop through a sass map of icons, rather than us having to import each group of icons. The map is defined in icons/supported.

To change the icons that a theme supports, overwrite the sass map with the new icons that should exist, then the loop in side `package` will output the correct CSS rules.

Fixes issue with `npm start` in bu-blocks.