### PR TITLE
Feature: Aspect ratio mixin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+* Adds a helper `aspect-ratio` mixin.
 * Adds a new function, `accessible-text()`, which returns WCAG 2.0-compliant
   text colors when given a background color and desired text color.
 * Adds es6 functionality via a variety of npm packages and Gruntfile
@@ -46,7 +47,7 @@
 * Adds `.sasslintrc` for grunt sasslint command and code climate.
 * Adds missing `bs-html-injector` package for the browserSync task.
 * Updates dependencies to resolve warnings about security vulnerabilities.
-* Updates `_tools-cgb.scss` with new icons implementation introduced in versopm
+* Updates `_tools-cgb.scss` with new icons implementation introduced in version
   `3.1.0`.
 
 ## 3.1.0

--- a/css-dev/burf-base/_mixins.scss
+++ b/css-dev/burf-base/_mixins.scss
@@ -37,6 +37,43 @@
 	}
 }
 
+/// A mixin for creating aspect ratios. Apply this mixin
+/// to the container that should be scalable in size, such
+/// as a video wrapper or an image wrapper. This will ensure
+/// the targeted element scales in size relative to its parent's
+/// width. It then absolutely positions the immediate child of
+/// this element so it fills the aspect ratio container.
+/// @example
+/// 		Adds aspect-ratio styling to a parent element and
+///         absolute positions its immediate child.
+/// 			$width: 200;
+///				$height: 150;
+///				.foo {
+///					@include aspect-ratio( $width, $height );
+///				}
+/// @group 02-mixins
+/// @access public
+/// @since 3.1.2
+
+@mixin aspect-ratio( $width, $height ) {
+	position: relative;
+
+	&:before {
+		content: "";
+		display: block;
+		padding-top: ( $height / $width ) * 100%;
+		width: 100%;
+	}
+
+	> * {
+		position: absolute;
+			top: 0;
+			right: 0;
+			bottom: 0;
+			left: 0;
+	}
+}
+
 /// A mixin for border-radius. Takes care of browser
 /// prefixes for you. You should always use this mixin
 /// when writing border-radius rules to ensure you're


### PR DESCRIPTION
Based on an article @rjfoleyiv shared: https://ratiobuddy.com/

Adds a helper mixin for defining aspect ratios on elements.

I particularly find this useful when defining scalable elements such as responsive videos or image containers that should scale proportionately.

Example Usage:

```sass
.video-wrapper {
    @include aspect-ratio( 16, 9 ); // A 16:9 container.
}

.image-frame {
    @include aspect-ratio( 7, 4 ); // A 7:4 container.
}
```

This mixin also targets the immediate child of this element to be positioned absolute to fill the container.