### PR TITLE
New Feature: Add em and rem helper functions

### DIFF
--- a/css-dev/burf-base/_mixins.scss
+++ b/css-dev/burf-base/_mixins.scss
@@ -969,3 +969,32 @@
 		@error 'The rgba-color mixin requires a valid CSS attribute to apply the color to, a valid RGBA color, and a valid background color to calculate the fallback color. \a Example usage: @include rgba-color(\'background-color\', rgba(black, 0.5), white);';
 	}
 }
+
+/// The root element font-size (html element).
+///
+/// @group 04-typography
+/// @access public
+/// @since 3.2.3
+$root-font-size: 16 !default;
+
+/// Helper function to output 'em' value based on supplied px value.
+///
+/// @parameter integer $pixels The value in pixels (without px unit)
+/// @parameter integer $context The parent container font-size context.
+/// @group 04-typography
+/// @access public
+/// @since 3.2.3
+@function em($pixels, $context: 16) {
+  @return #{$pixels / $context}em;
+}
+
+/// Helper function to output 'rem' value based on supplied px value.
+///
+/// @parameter integer $pixels The value in pixels (without px unit)
+/// @parameter integer $root-font-size The html element font-size.
+/// @group 04-typography
+/// @access public
+/// @since 3.2.3
+@function rem($pixels, $root-font-size) {
+  @return #{$pixels / $root-font-size}rem;
+}

--- a/css-dev/burf-base/_mixins.scss
+++ b/css-dev/burf-base/_mixins.scss
@@ -972,29 +972,29 @@
 
 /// The root element font-size (html element).
 ///
-/// @group 04-typography
+/// @group 02-mixins
 /// @access public
 /// @since 3.2.3
 $root-font-size: 16 !default;
 
 /// Helper function to output 'em' value based on supplied px value.
 ///
-/// @parameter integer $pixels The value in pixels (without px unit)
-/// @parameter integer $context The parent container font-size context.
-/// @group 04-typography
+/// @group 02-mixins
 /// @access public
 /// @since 3.2.3
+/// @param integer $pixels The value in pixels (without px unit)
+/// @param integer $context The parent container font-size context.
 @function em($pixels, $context: 16) {
   @return #{$pixels / $context}em;
 }
 
 /// Helper function to output 'rem' value based on supplied px value.
 ///
-/// @parameter integer $pixels The value in pixels (without px unit)
-/// @parameter integer $root-font-size The html element font-size.
-/// @group 04-typography
+/// @group 02-mixins
 /// @access public
 /// @since 3.2.3
+/// @param integer $pixels The value in pixels (without px unit)
+/// @param integer $root-font-size The html element font-size.
 @function rem($pixels, $root-font-size) {
   @return #{$pixels / $root-font-size}rem;
 }

--- a/css-dev/burf-base/_typography-tools.scss
+++ b/css-dev/burf-base/_typography-tools.scss
@@ -2,35 +2,6 @@
 // Typography Tools
 // =================================================================
 
-/// The root element font-size (html element).
-///
-/// @group 04-typography
-/// @access public
-/// @since 3.2.3
-$root-font-size: 16 !default;
-
-/// Helper function to output 'em' value based on supplied px value.
-///
-/// @parameter integer $pixels The value in pixels (without px unit)
-/// @parameter integer $context The parent container font-size context.
-/// @group 04-typography
-/// @access public
-/// @since 3.2.3
-@function em($pixels, $context: 16) {
-  @return #{$pixels / $context}em;
-}
-
-/// Helper function to output 'rem' value based on supplied px value.
-///
-/// @parameter integer $pixels The value in pixels (without px unit)
-/// @parameter integer $root-font-size The html element font-size.
-/// @group 04-typography
-/// @access public
-/// @since 3.2.3
-@function rem($pixels, $root-font-size) {
-  @return #{$pixels / $root-font-size}rem;
-}
-
 // Headings
 // -----------------------------------------------------------------
 

--- a/css-dev/burf-base/_typography-tools.scss
+++ b/css-dev/burf-base/_typography-tools.scss
@@ -2,6 +2,35 @@
 // Typography Tools
 // =================================================================
 
+/// The root element font-size (html element).
+///
+/// @group 04-typography
+/// @access public
+/// @since 3.2.3
+$root-font-size: 16 !default;
+
+/// Helper function to output 'em' value based on supplied px value.
+///
+/// @parameter integer $pixels The value in pixels (without px unit)
+/// @parameter integer $context The parent container font-size context.
+/// @group 04-typography
+/// @access public
+/// @since 3.2.3
+@function em($pixels, $context: 16) {
+  @return #{$pixels / $context}em;
+}
+
+/// Helper function to output 'rem' value based on supplied px value.
+///
+/// @parameter integer $pixels The value in pixels (without px unit)
+/// @parameter integer $root-font-size The html element font-size.
+/// @group 04-typography
+/// @access public
+/// @since 3.2.3
+@function rem($pixels, $root-font-size) {
+  @return #{$pixels / $root-font-size}rem;
+}
+
 // Headings
 // -----------------------------------------------------------------
 


### PR DESCRIPTION
This will allow developers to do things like

```
.big-ol-thang {
    max-width: rem( 780 );
    margin-bottom: rem( 30 );
}
```

Included these functions in typography since these are relative units that are based on typography settings on elements.