### PR TITLE
v5 profile title centering fix 247

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Fix #247 - BU Profiles Post title not centered.
+
 ## 5.0.0-alpha.7
 * Officially publishes to npm under the @bostonuniversity account!
 * Removes support for the tripadvisor icon in FontAwesome

--- a/burf-customizations/profiles/_profile-single.scss
+++ b/burf-customizations/profiles/_profile-single.scss
@@ -44,6 +44,7 @@ $color-profile-info-item:					$color-grayscale-5 !default;
 //
 // Since: 2.0.0
 
+:where(.single-profile) .page-title,
 .profile-single-name {
 	margin-bottom: 0;
 	text-align: center;


### PR DESCRIPTION
**Target**: 5.x versions.

Partially Fixes #247 by adding a new selector to apply the style since the classname does not appear to be added via the Responsive Framework title functions as originally intended. 


![Screen Shot 2024-02-01 at 3 10 57 PM](https://github.com/bu-ist/responsive-foundation/assets/3139096/af558e65-9e62-4855-9e32-05ca710adda9)
