### PR TITLE
add support for bluesky, x, and x-alt to icons and social menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Add icons for X, X-alt, and bluesky to icons and social menus.
 - 3.2.3 version hotfix: #269 Layout issue for Profiles Advanced View.
 
 ## 3.2.2

--- a/css-dev/burf-base/icons/_supported.scss
+++ b/css-dev/burf-base/icons/_supported.scss
@@ -172,6 +172,7 @@ $icons-responsive: (
 
 	// Social
 
+	bluesky: "\F652"
 	dropbox: "\F653",
 	dropbox-alt: "\F65A",
 	facebook: "\F610",
@@ -232,6 +233,8 @@ $icons-responsive: (
 	whatsapp: "\F642",
 	whatsapp-alt: "\F643",
 	wordpress: "\F621",
+	x: "\F615",
+	x-alt: "\F62B",
 	youtube: "\F630",
 	youtube-alt: "\F632",
 

--- a/css-dev/burf-theme/layout/_footer.scss
+++ b/css-dev/burf-theme/layout/_footer.scss
@@ -274,6 +274,10 @@ body {
 /// @since 2.0.0
 
 .menu-item {
+	[href*="bsky.app"] {
+		@extend %icon-bluesky;
+	}
+
 	[href*="dropbox.com"] {
 		@extend %icon-dropbox;
 	}
@@ -332,6 +336,10 @@ body {
 
 	[href*="twitter.com"] {
 		@extend %icon-twitter;
+	}
+
+	[href*="x.com"] {
+		@extend %icon-x;
 	}
 
 	[href*="vimeo.com"] {


### PR DESCRIPTION
Add icons for X, X-alt, and bluesky to icons and social menus.

- updates the supported icons map with the new icon references
- Adds x.com and bluesky urls to the social media menu link selectors for WordPress menus (footers, etc)