### PR TITLE
v5 bug fix `icon-link-alt` rename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 ## Unreleased
+- Fix name of `icon-link` from the incorrect `icon-link-alt` to `link-alt` in icons\supported.scss.
 - Fix #247 - BU Profiles Post title not centered.
 
 ## 5.0.0-alpha.7

--- a/burf-base/icons/_supported.scss
+++ b/burf-base/icons/_supported.scss
@@ -1504,7 +1504,7 @@ $icons-responsive: (
 	delete: $fa-var-times,
 	googleplus: $fa-var-google-plus-g,
 	pocket: $fa-var-get-pocket,
-	icon-link-alt: $fa-var-external-link-alt,
+	link-alt: $fa-var-external-link-alt,
 	instagram-alt: $fa-var-instagram,
 	navigateright: $fa-var-chevron-right,
 	navigateleft: $fa-var-chevron-left,


### PR DESCRIPTION
Fix name of `icon-link` from the incorrect `icon-link-alt` to `link-alt` in icons\supported.scss.