### PR TITLE
v5 Fix twitter icon, add buhub-wide and buhub-alt icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   - Move Twitter icon from FontAwsome list to BU Default Icons list so the updated X icon is used from BU Default Icons vs the Bird icon from FontAwesome for `icon-twitter`.
   - Add BU Hub Wide icon `icon-buhub-wide`. Use by calling `@extend %icon-buhub-wide;` This icon is the same as `icon-buhub` but has additional style overrides to scale it up.
   - Add BU Hub Alt icon `icon-buhub-alt`.  Use by calling `@extend %icon-buhub-alt;`
+- Bug fix: Restore dependency needed for compiling burf-tools in projects that use it. 
+
 
 ## 5.0.3
 - Bug fix: Restore dependencies needed for compiling in themes. 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,14 @@
 
 ## Unreleased
 
+## 5.0.4
+- Icon Changes: 
+  - Move Twitter icon from FontAwsome list to BU Default Icons list so the updated X icon is used from BU Default Icons vs the Bird icon from FontAwesome for `icon-twitter`.
+  - Add BU Hub Wide icon `icon-buhub-wide`. Use by calling `@extend %icon-buhub-wide;` This icon is the same as `icon-buhub` but has additional style overrides to scale it up.
+  - Add BU Hub Alt icon `icon-buhub-alt`.  Use by calling `@extend %icon-buhub-alt;`
+
 ## 5.0.3
-- Restore dependencies needed for compiling in themes. 
+- Bug fix: Restore dependencies needed for compiling in themes. 
 
 ## 5.0.2
 
@@ -13,6 +19,9 @@
 
 - Fix name of `icon-link` from the incorrect `icon-link-alt` to `link-alt` in icons\supported.scss.
 - Fix #247 - BU Profiles Post title not centered.
+- Add Blusky and X icons via BU Default Icons font.
+- Change how FontAwesome Brand icons are handled so the Fontawesome brands font is applied automatically via the icon mixin
+- Change how BU Default Icons are handled so the BU Default Icons font is applied automatically via the icon mixin
 
 ## 5.0.0-alpha.7
 

--- a/burf-base/icons/_mixins.scss
+++ b/burf-base/icons/_mixins.scss
@@ -100,6 +100,27 @@ $color-icons:										 unset !default;
 	white-space: nowrap;
 }
 
+// BU Hub Wide Icon Mixin
+//
+// Provides alternate icon-content override styles 
+// for the icon-buhub-wide icon to render it at
+// a readable size. This was added as a variant so as
+// to not break the existing icon-buhub icon. 
+//
+//
+// Access: Public
+//
+// Since: 5.0.4
+@mixin icon-buhub-wide-content {
+	--icon-buhub-wide-scalefactor: 4.6;
+	--icon-buhub-wide-fontsize: calc( 1em / (var(--icon-buhub-wide-scalefactor))); // Original font size.
+	line-height: calc(var(--icon-buhub-wide-fontsize) * 0.2);
+    margin-right: calc(var(--icon-buhub-wide-fontsize) * 0.5); 
+    padding-bottom: 0;
+    font-size: calc( 1em * (var(--icon-buhub-wide-scalefactor)));
+    height: calc(var(--icon-buhub-wide-fontsize) * 1.2);
+}
+
 // Icon content placeholder - before
 //
 // Provides base icon styles normalized across browsers and optimized
@@ -191,6 +212,10 @@ $color-icons:										 unset !default;
 		} @else if map-has-key( $icons-fontawesomebrands, $name ) {
 			font-family: "Font Awesome 5 Brands";
 			font-weight: 400;
-		} 
+		}
+		// Special fix for this specific buhub icon variant so it renders at a larger size making it readable.
+		@if $name == 'buhub-wide' {
+			@include icon-buhub-wide-content;
+		}
 	}
 }

--- a/burf-base/icons/_mixins.scss
+++ b/burf-base/icons/_mixins.scss
@@ -113,12 +113,13 @@ $color-icons:										 unset !default;
 // Since: 5.0.4
 @mixin icon-buhub-wide-content {
 	--icon-buhub-wide-scalefactor: 4.6;
-	--icon-buhub-wide-fontsize: calc( 1em / (var(--icon-buhub-wide-scalefactor))); // Original font size.
-	line-height: calc(var(--icon-buhub-wide-fontsize) * 0.2);
-	margin-right: calc(var(--icon-buhub-wide-fontsize) * 0.5); 
+	--icon-buhub-wide-fontsize: calc( 1em * (var(--icon-buhub-wide-scalefactor)));
+	--icon-buhub-wide-fontsize-original: calc( 1em / (var(--icon-buhub-wide-scalefactor))); // Original font size.
+	line-height: calc(var(--icon-buhub-wide-fontsize-original) * 0.2);
+	margin-right: calc(var(--icon-buhub-wide-fontsize-original) * 0.5); 
 	padding-bottom: 0;
-	font-size: calc( 1em * (var(--icon-buhub-wide-scalefactor)));
-	height: calc(var(--icon-buhub-wide-fontsize) * 1.2);
+	font-size: var(--icon-buhub-wide-fontsize);
+	height: calc(var(--icon-buhub-wide-fontsize-original) * 1.2);
 }
 
 // Icon content placeholder - before

--- a/burf-base/icons/_mixins.scss
+++ b/burf-base/icons/_mixins.scss
@@ -115,10 +115,10 @@ $color-icons:										 unset !default;
 	--icon-buhub-wide-scalefactor: 4.6;
 	--icon-buhub-wide-fontsize: calc( 1em / (var(--icon-buhub-wide-scalefactor))); // Original font size.
 	line-height: calc(var(--icon-buhub-wide-fontsize) * 0.2);
-    margin-right: calc(var(--icon-buhub-wide-fontsize) * 0.5); 
-    padding-bottom: 0;
-    font-size: calc( 1em * (var(--icon-buhub-wide-scalefactor)));
-    height: calc(var(--icon-buhub-wide-fontsize) * 1.2);
+	margin-right: calc(var(--icon-buhub-wide-fontsize) * 0.5); 
+	padding-bottom: 0;
+	font-size: calc( 1em * (var(--icon-buhub-wide-scalefactor)));
+	height: calc(var(--icon-buhub-wide-fontsize) * 1.2);
 }
 
 // Icon content placeholder - before

--- a/burf-base/icons/_supported.scss
+++ b/burf-base/icons/_supported.scss
@@ -1537,9 +1537,9 @@ $icons-budefaulticons: (
 * These icons are centered to match FontAwesome icon positioning.
 */
 $icons-budefaulticons-fontawesome-centered: (
-	twitter: '\F618',
-	x: '\F618',
-	bluesky: '\F655'
+	twitter: '\F703',
+	x: '\F703',
+	bluesky: '\F704'
 );
 
 // Merge BU Default font icons and BU Default Icons FontAwesome Centered Icons.

--- a/burf-base/icons/_supported.scss
+++ b/burf-base/icons/_supported.scss
@@ -1523,10 +1523,12 @@ $icons-budefaulticons: (
 	// BU Hub Indicator
 	buhub: '\F700',
 	buhub-alt: '\F702',
+	buhub-wide: '\F700',
 	questionmark: '\2753',
 
 	rhett: '\F701',
 	bluesky: '\F652',
+	twitter: '\F611',
 	x: '\F615',
 	x-alt: '\F62B',
 );

--- a/burf-base/icons/_supported.scss
+++ b/burf-base/icons/_supported.scss
@@ -1533,6 +1533,18 @@ $icons-budefaulticons: (
 	x-alt: '\F62B',
 );
 
+/*
+* These icons are centered to match FontAwesome icon positioning.
+*/
+$icons-budefaulticons-fontawesome-centered: (
+	twitter: '\F618',
+	x: '\F618',
+	bluesky: '\F655'
+);
+
+// Merge BU Default font icons and BU Default Icons FontAwesome Centered Icons.
+$icons-budefaulticons: map_merge( $icons-budefaulticons, $icons-budefaulticons-fontawesome-centered );
+
 // Merge Responsive Icons and BU Default font icons.
 $icons-responsive: map_merge( $icons-responsive, $icons-budefaulticons );
 

--- a/burf-base/package.json
+++ b/burf-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/burf-base",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "homepage": "https://bu-ist.github.io/responsive-foundation/",
   "description": "A sensible boilerplate and library of styles for responsive web design, based on the best ideas from Foundation and Bootstrap.",
   "authors": [

--- a/burf-base/package.json
+++ b/burf-base/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/burf-base",
-  "version": "5.0.4",
+  "version": "5.0.4-rc.1",
   "homepage": "https://bu-ist.github.io/responsive-foundation/",
   "description": "A sensible boilerplate and library of styles for responsive web design, based on the best ideas from Foundation and Bootstrap.",
   "authors": [

--- a/burf-customizations/package.json
+++ b/burf-customizations/package.json
@@ -44,7 +44,7 @@
     ]
   },
   "dependencies": {
-    "@bostonuniversity/burf-base": "^5.0.4",
-    "@bostonuniversity/burf-theme": "^5.0.4"
+    "@bostonuniversity/burf-base": "^5.0.4-rc.1",
+    "@bostonuniversity/burf-theme": "^5.0.4-rc.1"
   }
 }

--- a/burf-customizations/package.json
+++ b/burf-customizations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/burf-customizations",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "homepage": "https://bu-ist.github.io/responsive-foundation/",
   "description": "A sensible boilerplate and library of styles for WordPress, intended to work with the Boston University Responsive Framework parent theme.",
   "authors": [
@@ -44,7 +44,7 @@
     ]
   },
   "dependencies": {
-    "@bostonuniversity/burf-base": "^5.0.3",
-    "@bostonuniversity/burf-theme": "^5.0.3"
+    "@bostonuniversity/burf-base": "^5.0.4",
+    "@bostonuniversity/burf-theme": "^5.0.4"
   }
 }

--- a/burf-customizations/package.json
+++ b/burf-customizations/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/burf-customizations",
-  "version": "5.0.4",
+  "version": "5.0.4-rc.1",
   "homepage": "https://bu-ist.github.io/responsive-foundation/",
   "description": "A sensible boilerplate and library of styles for WordPress, intended to work with the Boston University Responsive Framework parent theme.",
   "authors": [

--- a/burf-theme/layout/_footer.scss
+++ b/burf-theme/layout/_footer.scss
@@ -378,7 +378,7 @@ body {
 	}
 
 	[href*="twitter.com"] {
-		@extend %icon-twitter;
+		@extend %icon-x;
 	}
 
 	[href*="vimeo.com"] {

--- a/burf-theme/package.json
+++ b/burf-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/burf-theme",
-  "version": "5.0.4",
+  "version": "5.0.4-rc.1",
   "homepage": "https://bu-ist.github.io/responsive-foundation/",
   "description": "A sensible boilerplate and library of styles for WordPress, intended to work with the Boston University Responsive Framework parent theme.",
   "authors": [

--- a/burf-theme/package.json
+++ b/burf-theme/package.json
@@ -46,6 +46,6 @@
     ]
   },
   "dependencies": {
-    "@bostonuniversity/burf-base": "^5.0.4"
+    "@bostonuniversity/burf-base": "^5.0.4-rc.1"
   }
 }

--- a/burf-theme/package.json
+++ b/burf-theme/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/burf-theme",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "homepage": "https://bu-ist.github.io/responsive-foundation/",
   "description": "A sensible boilerplate and library of styles for WordPress, intended to work with the Boston University Responsive Framework parent theme.",
   "authors": [
@@ -46,6 +46,6 @@
     ]
   },
   "dependencies": {
-    "@bostonuniversity/burf-base": "^5.0.3"
+    "@bostonuniversity/burf-base": "^5.0.4"
   }
 }

--- a/burf-tools/package.json
+++ b/burf-tools/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com:bu-ist/responsive-foundation.git",
     "directory": "burf-tools"
   },
-  "devDependencies": {
+  "dependencies": {
     "@bostonuniversity/burf-base": "^5.0.4"
   }
 }

--- a/burf-tools/package.json
+++ b/burf-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/burf-tools",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "homepage": "https://bu-ist.github.io/responsive-foundation/",
   "description": "BU Responsive Foundation for those who only want the very basic of basics, and to print absolutely minimal CSS. Only mixins and placeholders are supported in this partial, and only pieces which are used will print. Useful for plugin development where you want your dependencies and extra CSS to be at an absolute minimum, or for development which will occur in another pre-existing framework or environment with its own normalizing partials and other opinionated stuff.",
   "authors": [
@@ -22,6 +22,6 @@
     "directory": "burf-tools"
   },
   "devDependencies": {
-    "@bostonuniversity/burf-base": "^5.0.3"
+    "@bostonuniversity/burf-base": "^5.0.4"
   }
 }

--- a/burf-tools/package.json
+++ b/burf-tools/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@bostonuniversity/burf-tools",
-  "version": "5.0.4",
+  "version": "5.0.4-rc.1",
   "homepage": "https://bu-ist.github.io/responsive-foundation/",
   "description": "BU Responsive Foundation for those who only want the very basic of basics, and to print absolutely minimal CSS. Only mixins and placeholders are supported in this partial, and only pieces which are used will print. Useful for plugin development where you want your dependencies and extra CSS to be at an absolute minimum, or for development which will occur in another pre-existing framework or environment with its own normalizing partials and other opinionated stuff.",
   "authors": [

--- a/burf-tools/package.json
+++ b/burf-tools/package.json
@@ -22,6 +22,6 @@
     "directory": "burf-tools"
   },
   "dependencies": {
-    "@bostonuniversity/burf-base": "^5.0.4"
+    "@bostonuniversity/burf-base": "^5.0.4-rc.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "responsive-foundation",
-  "version": "5.0.4",
+  "version": "5.0.4-rc.1",
   "homepage": "https://github.com/bu-ist/responsive-foundation",
   "description": "A front-end framework for developing responsive sites at Boston University.",
   "authors": [

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "responsive-foundation",
-  "version": "5.0.3",
+  "version": "5.0.4",
   "homepage": "https://github.com/bu-ist/responsive-foundation",
   "description": "A front-end framework for developing responsive sites at Boston University.",
   "authors": [


### PR DESCRIPTION
- Icon Changes: 
  - Move Twitter icon from FontAwsome list to BU Default Icons list so the updated X icon is used from BU Default Icons vs the Bird icon from FontAwesome for `icon-twitter`.
  - Add BU Hub Wide icon `icon-buhub-wide`. Use by calling `@extend %icon-buhub-wide;` This icon is the same as `icon-buhub` but has additional style overrides to scale it up.
  - Add BU Hub Alt icon `icon-buhub-alt`.  Use by calling `@extend %icon-buhub-alt;`
- Bug fix: Restore dependency needed for compiling burf-tools in projects that use it. 