### PR TITLE
V3 add additional social link icon support to menus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 3.2.6
+- Add medium.com, renren.com, and weibo.com support to social menu icon styles
+
 ## 3.2.5
 
 - `npm audit fix`

--- a/css-dev/burf-theme/layout/_footer.scss
+++ b/css-dev/burf-theme/layout/_footer.scss
@@ -310,6 +310,10 @@ body {
 		@extend %icon-linkedin;
 	}
 
+	[href*="medium.com"] {
+		@extend %icon-medium;
+	}
+
 	[href*="pinterest.com"] {
 		@extend %icon-pinterest;
 	}
@@ -326,6 +330,10 @@ body {
 		@extend %icon-reddit;
 	}
 
+	[href*="renren.com"] {
+		@extend %icon-renren;
+	}
+
 	[href*="snapchat.com"] {
 		@extend %icon-snapchat;
 	}
@@ -335,7 +343,11 @@ body {
 	}
 
 	[href*="twitter.com"] {
-		@extend %icon-twitter;
+		@extend %icon-x;
+	}
+
+	[href*="weibo.com"] {
+		@extend %icon-weibo;
 	}
 
 	[href*="x.com"] {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "responsive-foundation",
-  "version": "3.2.5",
+  "version": "3.2.6",
   "homepage": "https://github.com/bu-ist/responsive-foundation",
   "description": "A front-end framework for developing responsive sites at Boston University.",
   "authors": [


### PR DESCRIPTION
V3 was missing support for Medium.com, RenRen.com, and Weibo.com icons in social menus. The icons are present but the styles for automatically applying them based on the url are missing in this older version of Foundation. This PR adds them and bumps the version.