### PR TITLE
standardize container variables

### DIFF
--- a/burf-base/_config.scss
+++ b/burf-base/_config.scss
@@ -996,32 +996,39 @@ $color-hub:                        			 #767676;
 // --bu--content--width-default-clamped and --bu--content--width-wide-clamped are also used in a themese settings.mjs (theme.json).
 
 :root {
-	--bu--content--padding-block: 1rem;
-	--bu--content--padding-inline: 1rem;
-	--bu--content--margin-block: 1rem;
-	--bu--content--margin-inline: 1rem;
-	--bu--content--column-gap: var( --bu--content--margin-inline );
-	--bu--content--row-gap: var( --bu--content--margin-block );
+	//
 
-	--bu--content--button-padding-block: 0.5em;
-	--bu--content--button-padding-inline: 1.25em;
+	// Primitives 
+	--size-fluid-spacing: clamp(1rem, 1.7vw + 0.47rem, 2rem); // 1rem - 2rem
+	--size-fluid-spacing-lg: clamp(2rem, 2.612vw + 1.388rem, 4rem); // 2rem - 4rem
 
-	--bu--content--width-default-base: 800px;
-	--bu--content--width-default-clamped: clamp( 0%, var(--bu--content--width-default-base), calc(100% - ( var(--bu--content--margin-inline) * 2 ) ) );
+	// Spacing.
+	--bu-container-spacing: var(--size-fluid-spacing); // Spacing is the block spacing between elements.
+	--bu-container-gutter: var(--size-fluid-spacing); // Gutter is the inline space between the viewport and the container.
+	--bu-container-column-gap: var(--size-fluid-spacing); // Inline spacing between internal elements of a parent element.
+	--bu-container-row-gap: var(--size-fluid-spacing-lg); // Block spacing between internal elements of a parent element.
+	--bu-container-padding-vertical: var(--size-fluid-spacing); 
+	--bu-container-padding-horizontal: var(--size-fluid-spacing);
 
-	--bu--content--width-float-min-width: 300px;
-	--bu--content--width-float-base: calc( var(--bu--content--width-default-base) * 0.5 );
-	--bu--content--width-float-base: calc( var(--bu--content--width-default-base) * 0.5 );
-	--bu--content--width-float-clamped: clamp( var(--bu--content--width-float-min-width), var(--bu--content--width-float-base), calc(100% - ( var(--bu--content--margin-inline) * 2 ) ) );
+	// Sizing.
+	--bu-container-max-inline-size--guttered: calc( 100% - ( var( --bu-container-gutter ) * 2 ) );
+	--bu-container-max-inline-size--content: 800px;
+	--bu-container-max-inline-size--wide: 1200px;
+	--bu-container-max-inline-size--full: 100%;
+	--bu-container-max-inline-size--float: calc(var(--bu-container-size--content) * 0.5);
 
-	--bu--content--width-nested-float-base: 50%;
-	--bu--content--width-nested-float-clamped: clamp( var(--bu--content--width-float-min-width), var(--bu--content--width-nested-float-base), calc(100% - ( var(--bu--content--margin-inline) * 2 ) ) );
+	--bu-container-size--content: min( var( --bu-container-max-inline-size--content ), var( --bu-container-max-inline-size--guttered ) );
+	--bu-container-size--wide: min( var( --bu-container-max-inline-size--wide ), var( --bu-container-max-inline-size--guttered ) );
+	--bu-container-size--full: var( --bu-container-max-inline-size--full );
+	--bu-container-size--float: clamp( var( --bu-container-min-inline-size--float, 50% ), var( --bu-container-max-inline-size--float ), calc( 100% - ( var( --bu-container-gutter ) * 2 ) ) );
 
-	--bu--content--width-wide-base: 1000px;
-	--bu--content--width-wide-clamped: clamp( 0%, var(--bu--content--width-wide-base), calc(100% - ( var( --bu--content--margin-inline ) * 2 ) ) );
 
-	--bu--content--margin-offset: clamp(0%, 50% - ( var(--bu--content--width-default-clamped) * 0.5 ), 100%);
+	// Offsets - an offset is the distance from the edge of the viewport to the start of the named container size.
+	--bu-container-offset--wide:  min( 50% - ( var( --bu-container-size--wide ) * 0.5 ), 100% );
+	--bu-container-offset--content:  min( 50% - ( var( --bu-container-size--content ) * 0.5 ), 100% );
 
+	// Pulls - a pull is the distance from the edge of the content container to the start of the named container size.
+	--bu-container-pull--wide: calc((var(--bu-container-size--wide) - var(--bu-container-size--content)) * 0.5);
 }
 
 // Selector maps

--- a/burf-customizations/layout/_breadcrumbs.scss
+++ b/burf-customizations/layout/_breadcrumbs.scss
@@ -15,7 +15,7 @@
 
 	grid-area: breadcrumbs;
 
-	width: var(--bu--content--width-default-clamped);
+	width: var( --bu-container-size--content );
 
 	* {
 		line-height: 1em;

--- a/burf-theme/_mixins.scss
+++ b/burf-theme/_mixins.scss
@@ -8,7 +8,7 @@
 
 @mixin contentarea-vertical-spacings {
 	%contentarea-elements {
-		margin-block: var( --bu--content--margin-block );
+		margin-block: var( --bu-container-spacing );
 	}
 }
 @mixin contentarea-base-styles {
@@ -20,8 +20,8 @@
 		//background: #e661; //placeholder test color - To be removed before merging
 
 		&.has-background {
-			padding-block: var( --bu--content--padding-block );
-			padding-inline: var( --bu--content--padding-inline );
+			padding-block: var( --bu-container-padding-vertical );
+			padding-inline: var( --bu-container-padding-horizontal );
 
 			> * {
 				&:first-child {
@@ -41,7 +41,7 @@
 	> {
 		* {
 			margin-inline: auto;
-			max-width: var( --bu--content--width-default-clamped );
+			max-width: var( --bu-container-size--content );
 		}
 	}
 }
@@ -51,7 +51,7 @@
 		box-sizing: border-box;
 		clear: both;
 		margin-inline: auto;
-		max-width: var( --bu--content--width-wide-clamped );
+		max-width: var( --bu-container-size--wide );
 	}
 
 	#{map.get( $selectors, 'alignfull' )} {
@@ -64,18 +64,18 @@
 	#{map.get( $selectors, 'alignright' )},
 	#{map.get( $selectors, 'aligncenter' )} {
 		margin-block-start: 0;
-		margin-block-end: var( --bu--content--margin-block );
-		max-width: var( --bu--content--width-nested-float-clamped );
+		margin-block-end: var( --bu-container-spacing );
+		max-width: 50%;
 	}
 
 	#{map.get( $selectors, 'alignleft' )} {
 		float: left;
-		margin-inline-end: var( --bu--content--margin-inline ) !important; // !important needed to toverride margin-left: auto !important set on the block editor
+		margin-inline-end: var( --bu-container-gutter ) !important; // !important needed to toverride margin-left: auto !important set on the block editor
 	}
 
 	#{map.get( $selectors, 'alignright' )} {
 		float: right;
-		margin-inline-start: var( --bu--content--margin-inline ) !important; // !important needed to toverride margin-left: auto !important set on the block editor
+		margin-inline-start: var( --bu-container-gutter ) !important; // !important needed to toverride margin-left: auto !important set on the block editor
 	}
 
 	// Top level content styles
@@ -83,22 +83,24 @@
 	// These styles use a child combinator so as to only target unnested blocks and page elements.
 	> {
 		* {
+
+			--bu-container-min-inline-size--float: 300px;
 			margin-inline: auto;
-			max-width: var( --bu--content--width-default-clamped );
+			max-width: var( --bu-container-size--content );
 		}
 
 		#{map.get( $selectors, 'alignleft' )},
 		#{map.get( $selectors, 'alignright' )},
 		#{map.get( $selectors, 'aligncenter' )} {
-			max-width: var( --bu--content--width-float-clamped );
+			max-width: var( --bu-container-size--float );
 		}
 
 		#{map.get( $selectors, 'alignleft' )} {
-			margin-inline-start: var( --bu--content--margin-offset ) !important; // !important needed to toverride margin-left: auto !important set on the block editor
+			margin-inline-start: var( --bu-container-offset--content ) !important; // !important needed to toverride margin-left: auto !important set on the block editor
 		}
 
 		#{map.get( $selectors, 'alignright' )} {
-			margin-inline-end: var( --bu--content--margin-offset ) !important; // !important needed to toverride margin-left: auto !important set on the block editor
+			margin-inline-end: var( --bu-container-offset--content ) !important; // !important needed to toverride margin-left: auto !important set on the block editor
 		}
 	}
 }

--- a/burf-theme/content/_gravity-forms.scss
+++ b/burf-theme/content/_gravity-forms.scss
@@ -4,6 +4,6 @@
 
 .gform_legacy_markup_wrapper {
     .content-area > & {
-        max-width: var( --gform-legacy-width-default, var( --bu--content--width-default-clamped ) );
+        max-width: var( --gform-legacy-width-default, var( --bu-container-size--content ) );
     }
 }

--- a/burf-theme/content/blocks/_button.scss
+++ b/burf-theme/content/blocks/_button.scss
@@ -10,6 +10,6 @@
     }
 
     .wp-block-button__link {
-        padding: var( --bu--content--button-padding-block ) var( --bu--content--button-padding-inline );
+        padding: var( --wp-block-button-padding-block, 0.5em ) var( --wp-block-button-padding-inline, 1.25em );
     }
 }

--- a/burf-theme/content/blocks/_column.scss
+++ b/burf-theme/content/blocks/_column.scss
@@ -11,8 +11,8 @@
 // A selector map can be passed thru, by default it is set to pass in $frontend-selectors
 
 .wp-block-columns {
-	column-gap: var( --bu--content--column-gap );
-	row-gap: var( --bu--content--row-gap );
+	column-gap: var( --bu-container-column-gap );
+	row-gap: var( --bu-container-row-gap );
 	margin-block: 0;
 }
 

--- a/burf-theme/content/blocks/_media-text.scss
+++ b/burf-theme/content/blocks/_media-text.scss
@@ -8,7 +8,7 @@
 
 .wp-block-media-text {
 	&.has-background {
-		--bu--content--padding-block: 0; 
-		--bu--content--padding-inline: 0;
+		--bu-container-padding-vertical: 0; 
+		--bu-container-padding-horizontal: 0;
 	}
 }

--- a/burf-theme/content/blocks/_post-date.scss
+++ b/burf-theme/content/blocks/_post-date.scss
@@ -3,5 +3,5 @@
 // =================================================================
 // Preliminary layout styles for the Query Loops Post date block
 .wp-block-post-date {
-	margin-block: var( --bu--content--margin-block );
+	margin-block: var( --bu-container-spacing );
 }

--- a/burf-theme/content/blocks/_post-featured-image.scss
+++ b/burf-theme/content/blocks/_post-featured-image.scss
@@ -4,7 +4,7 @@
 // Preliminary layout styles for the query loops Post image block
 
 .wp-block-post-featured-image {
-	margin-block: var( --bu--content--margin-block );
+	margin-block: var( --bu-container-spacing );
 
 	a {
 		width: 100%;

--- a/burf-theme/content/blocks/_post-template-editor.scss
+++ b/burf-theme/content/blocks/_post-template-editor.scss
@@ -5,6 +5,6 @@
 
 .wp-block-post-template {
 	li {
-		--bu--content--width-default-clamped: none;
+		--bu-container-size--content: none;
 	}	
 }	

--- a/burf-theme/content/blocks/_post-template.scss
+++ b/burf-theme/content/blocks/_post-template.scss
@@ -4,8 +4,8 @@
 // Preliminary layout styles for the Query Loops Post Template Block block
 
 .wp-block-post-template {
-	column-gap: var( --bu--content--column-gap );
-	row-gap: var( --bu--content--row-gap );
+	column-gap: var( --bu-container-column-gap );
+	row-gap: var( --bu-container-row-gap );
 	
 
 	&.is-flex-container.is-flex-container {		
@@ -23,7 +23,7 @@
 		/* setting */
 		--min-column-size: 20ch;
 		--column-count: 1;
-		--gap: var( --bu--content--column-gap );
+		--gap: var( --bu-container-column-gap );
 		
 		/* calculations */
 		--breakpoint: calc(var(--min-column-size) * var(--column-count) + (var(--gap) * (var(--column-count) - 1)) );

--- a/burf-theme/content/blocks/_pullquote.scss
+++ b/burf-theme/content/blocks/_pullquote.scss
@@ -5,7 +5,7 @@
 
 .wp-block-pullquote {
 	padding-block: var( --pullquote-padding-block, 2em );
-	padding-inline: var( --pullquote-padding-block, var( --bu--content--margin-inline ) );
+	padding-inline: var( --pullquote-padding-block, var( --bu-container-spacing ) );
 
 	:where( blockquote ) {
 		margin: 0;

--- a/burf-theme/content/blocks/_separator.scss
+++ b/burf-theme/content/blocks/_separator.scss
@@ -17,7 +17,7 @@
 	}
 
 	&.has-background {
-		--bu--content--padding-block: 0; 
-		--bu--content--padding-inline: 0;
+		--bu-container-padding-vertical: 0; 
+		--bu-container-padding-horizontal: 0;
 	}
 }

--- a/burf-theme/layout/_sidebar.scss
+++ b/burf-theme/layout/_sidebar.scss
@@ -5,8 +5,8 @@
 .sidebar {
 	background-color: var( --sidebar-background-color, #fafafa );
 	grid-area: sidebar;
-	padding-block: var(--bu--content--padding-block);
-	padding-inline: var(--bu--content--padding-inline);
+	padding-block: var( --bu-container-padding-vertical );
+	padding-inline: var( --bu-container-padding-horizontal );
 
 	// max-width: clamp( 20vw, 360px, 33.3333vw);
 


### PR DESCRIPTION
This work standardizes the classes used for the content area container to be more inline with the work being done for bu-base. Some of the styles associated with still need additional refactoring. as some of the calculations for certain variables has changed.

### Sandbox Link
https://id-charlie-upgrade-58.cms-devl.bu.edu/core-3/html-elements/lorem-ipsum-dolor-sit-amet/