### PR TITLE
Minor edits to address breadcrumb nav margin and content container sizing

### DIFF
--- a/burf-customizations/layout/_breadcrumbs.scss
+++ b/burf-customizations/layout/_breadcrumbs.scss
@@ -9,7 +9,7 @@
 	display: flex;
 	font-family: var( --nav-crumb-font-family, var( --bu-base-font-family, sans-serif ) );
 	font-size: var( --nav-crumb-font-size, 1rem );
-	margin-block: var(--bu--content--margin-block);
+	margin-block: var(--bu--content--margin-block, 1em);
 	margin-inline: auto;
 	padding: var( --nav-crumbs-padding-block, 0.75em ) var( --nav-crumbs-padding-inline, 0 );
 

--- a/burf-theme/layout/_content-container.scss
+++ b/burf-theme/layout/_content-container.scss
@@ -25,7 +25,7 @@ $color-content-bg:                         $color-grayscale-f !default;
 		"sidebar";
 
 	@include breakpoint( $sm ) {
-		grid-template-columns: auto 1fr;
+		grid-template-columns: 1fr auto;
 		grid-template-rows: auto 1fr auto;
 		grid-template-areas:
 			"breadcrumbs	sidebar"


### PR DESCRIPTION
- Adds a missing fallback value to the breadcrumb navigation's block margin
- Fixes the column sizing for the content container 